### PR TITLE
Shift ICID to DEV IFRIC Cluster

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -40,9 +40,9 @@ jobs:
     uses: IndustryFusion/GitOpsRepo/.github/workflows/deploy.yaml@main
     with:
       APPS: icid
-      NAMESPACE: iff50
+      NAMESPACE: icid-service
       DOCKER_TAG: ${{ needs.build.outputs.DOCKER_TAG }}
-      CLUSTER: IFF-Dev-SmartFactory      
+      CLUSTER: IFF-DEV-DPP-IFRIC
     secrets:
       PRIVATE_GITHUB_TOKEN: ${{ secrets.PRIVATE_GITHUB_TOKEN }}
       ICID_MONGO_URL_DEV: ${{ secrets.ICID_MONGO_URL_DEV }}


### PR DESCRIPTION
Shifting Fleet, Factory and ICID applications from the Dev Smartfactory to the Dev Ifric Cluster.